### PR TITLE
Fix race condition in starting nodes, reduce verbosity

### DIFF
--- a/gaitmesh_ros/src/annotate_cloud_gaits_continuous.cpp
+++ b/gaitmesh_ros/src/annotate_cloud_gaits_continuous.cpp
@@ -25,10 +25,16 @@ public:
 
         client_recast_ = nh_.serviceClient<recast_ros::InputMeshSrv>("/recast_node/input_mesh");
         cloud_mesh_sub_ = nh_.subscribe("/gaitmesh_ros/input_cloud_mesh", 1, &ContinuousGaitMesh::cloudMeshCallback, this);
+
+        ROS_INFO("Wait for Recast node update serve to come online...");
+        client_recast_.waitForExistence();
+        ROS_INFO("Recast node online!");
     }
 
     void processCloudMesh()
     {
+        ROS_INFO_STREAM("Processing CloudMesh: Cloud size=" << cloud_mesh_.cloud.data.size() << " - Mesh Polygon Size=" << cloud_mesh_.mesh.polygons.size());
+
         pcl::PCLPointCloud2 pcl_pc2;
         pcl::PolygonMesh mesh;
         pcl_conversions::toPCL(cloud_mesh_.cloud, pcl_pc2);

--- a/gaitmesh_ros/src/gaitmesh_ros.cpp
+++ b/gaitmesh_ros/src/gaitmesh_ros.cpp
@@ -161,39 +161,6 @@ std::vector<char> annotateCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud,
 
     // back-project features to mesh
     std::vector<char> mesh_labels(mesh.polygons.size(), (char)0);
-    if (false)
-    {
-        ROS_INFO("Back-projecting annotations to mesh...");
-        // tree
-        pcl::search::KdTree<pcl::PointXYZRGBNormal>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZRGBNormal>());
-        tree->setInputCloud(gait_cloud);
-        // go through all mesh triangles
-        pcl::PointCloud<pcl::PointXYZRGBNormal> mesh_cloud;
-        pcl::fromPCLPointCloud2(mesh.cloud, mesh_cloud);
-        for (int i = 0; i < mesh.polygons.size(); i++)
-        {
-            // get closest annotated-cloud point
-            Eigen::Vector3d v0 = pcl2eig(mesh_cloud.points[mesh.polygons[i].vertices[0]]);
-            Eigen::Vector3d v1 = pcl2eig(mesh_cloud.points[mesh.polygons[i].vertices[1]]);
-            Eigen::Vector3d v2 = pcl2eig(mesh_cloud.points[mesh.polygons[i].vertices[2]]);
-            Eigen::Vector3d vc = (v0 + v1 + v2) / 3;
-            pcl::PointXYZRGBNormal pt_center = eig2pcl(vc);
-            std::vector<int> k_indices;
-            std::vector<float> k_distances;
-            tree->nearestKSearch(pt_center, 1, k_indices, k_distances);
-            // assign label to triangle
-            const pcl::PointXYZRGBNormal& nn = gait_cloud->points[k_indices[0]];
-            char label = 2;
-            if (nn.g > 0)
-                label = 1;  // trot
-            else if (nn.b > 0)
-                label = 2;  // step
-            else
-                label = 0;  // unwalkable
-            mesh_labels[i] = label;
-        }
-    }
-    else
     {
         ROS_DEBUG("Back-projecting annotations to mesh...");
         // tree

--- a/gaitmesh_ros/src/gaitmesh_ros.cpp
+++ b/gaitmesh_ros/src/gaitmesh_ros.cpp
@@ -85,6 +85,13 @@ std::vector<char> annotateCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud,
                                 pcl::PointCloud<pcl::PointNormal>::Ptr normal_cloud,
                                 pcl::PointCloud<pcl::PointXYZRGBNormal>::Ptr gait_cloud)
 {
+    // Check if the cloud is empty - if it is, return:
+    if (input_cloud->size() == 0)
+    {
+        ROS_WARN_STREAM("Input cloud is empty - not running annotation. Cloud size = " << input_cloud->size() << ", Mesh #Polygons = " << mesh.polygons.size());
+        return std::vector<char>();
+    }
+
     // Step 2: Outlier filter
     // if (!outlier_removal_cloud) outlier_removal_cloud.reset(new pcl::PointCloud<pcl::PointXYZ>());
     if (false)

--- a/gaitmesh_ros/src/gaitmesh_ros.cpp
+++ b/gaitmesh_ros/src/gaitmesh_ros.cpp
@@ -89,7 +89,7 @@ std::vector<char> annotateCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud,
     // if (!outlier_removal_cloud) outlier_removal_cloud.reset(new pcl::PointCloud<pcl::PointXYZ>());
     if (false)
     {
-        ROS_INFO("Removing outliers...");
+        ROS_DEBUG("Removing outliers...");
         pcl::RadiusOutlierRemoval<pcl::PointXYZ> sor;
         sor.setInputCloud(input_cloud);
         sor.setRadiusSearch(0.2);
@@ -104,7 +104,7 @@ std::vector<char> annotateCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud,
     // Step 3: Run terrain-related filters
     // if (!normal_cloud) normal_cloud.reset(new pcl::PointCloud<pcl::PointNormal>());
     {
-        ROS_INFO("Estimating normals...");
+        ROS_DEBUG("Estimating normals...");
         const float radius = radius_normals;
         pcl::NormalEstimationOMP<pcl::PointXYZ, pcl::Normal> ne;
         ne.setInputCloud(input_cloud);
@@ -119,7 +119,7 @@ std::vector<char> annotateCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud,
     // Step 4: Gait annotation
     // if (!gait_cloud) gait_cloud.reset(new pcl::PointCloud<pcl::PointXYZRGBNormal>());
     {
-        ROS_INFO("Running filters...");
+        ROS_DEBUG("Running filters...");
         const float radius = radius_robot;
         gait_cloud->points.reserve(normal_cloud->points.size());
         pcl::search::KdTree<pcl::PointNormal>::Ptr tree(new pcl::search::KdTree<pcl::PointNormal>());
@@ -195,13 +195,16 @@ std::vector<char> annotateCloud(pcl::PointCloud<pcl::PointXYZ>::Ptr input_cloud,
     }
     else
     {
-        ROS_INFO("Back-projecting annotations to mesh...");
+        ROS_DEBUG("Back-projecting annotations to mesh...");
         // tree
         pcl::search::KdTree<pcl::PointXYZRGBNormal>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZRGBNormal>());
         tree->setInputCloud(gait_cloud);
         // go through all mesh triangles
         pcl::PointCloud<pcl::PointXYZRGBNormal> mesh_cloud;
+        // This line is expected to throw warnings - thus disable them:
+        pcl::console::setVerbosityLevel(pcl::console::L_ALWAYS);
         pcl::fromPCLPointCloud2(mesh.cloud, mesh_cloud);
+        pcl::console::setVerbosityLevel(pcl::console::L_WARN);  // Re-enable
         for (int i = 0; i < mesh.polygons.size(); i++)
         {
             // we will vote for each of the gait-controller options

--- a/gaitmesh_ros/src/meshlab_reconstruction.cpp
+++ b/gaitmesh_ros/src/meshlab_reconstruction.cpp
@@ -23,7 +23,7 @@ pcl::PolygonMesh reconstructMeshMeshlab(pcl::PointCloud<pcl::PointXYZ>::Ptr clou
     pcl::io::savePLYFile(cloud_output_file, *cloud);
     // run meshlab server
     std::stringstream cmd;
-    cmd << "meshlabserver -i " << cloud_output_file << " -o " << mesh_output_file << " -s " << meshlab_server_file;
+    cmd << "meshlabserver -i " << cloud_output_file << " -o " << mesh_output_file << " -s " << meshlab_server_file << " > /dev/null 2> /dev/null";
     // TODO: Capture output
     int system_result = system(cmd.str().c_str());
     // load mesh from file

--- a/gaitmesh_ros/src/publish_initial_cloud.cpp
+++ b/gaitmesh_ros/src/publish_initial_cloud.cpp
@@ -52,11 +52,12 @@ int main(int argc, char* argv[])
     if (input_clouds_not_mesh)
     {
         // load and join clouds
-        ROS_INFO("Loading clouds...");
         if (cloud_paths.size() == 0)
         {
-            ROS_ERROR("No point cloud provided");
+            ROS_ERROR("No point cloud provided - shutting down publish_initial_cloud node.");
+            return EXIT_SUCCESS;
         }
+        ROS_INFO("Loading clouds...");
         for (unsigned int i = 0; i < cloud_paths.size(); i++)
         {
             ROS_INFO("Processing cloud %d", i);
@@ -94,8 +95,8 @@ int main(int argc, char* argv[])
     initial_msg.reference_point.z = reference_point_z;
     cloud_mesh_pub.publish(initial_msg);
 
-    ros::Rate rate(1 / 5);  // Hz
-    rate.sleep();           // Sleep for 5s, then exit
+    ros::Rate rate(1 / 5.0);  // Hz
+    rate.sleep();             // Sleep for 5s, then exit
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR contains a number of changes to reduce verbosity and wait for existence of services when launching the different launch files - otherwise some of the services aren't set up proper.

cc: @dan-armstrong 